### PR TITLE
Corrected the GPL version in COPYING file

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -5,7 +5,7 @@ LibCEC is copyright Pulse-Eight ( http://www.pulse-eight.com/ )
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
+the Free Software Foundation, either version 2 of the License, or
 (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
Was previously 3 in the intro paragraph and 2 elsewhere;
changed to 2 in the intro paragraph.