### PR TITLE
Added setuptools to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import setuptools
 from distutils.core import setup, Extension
 
 # Remove the "-Wstrict-prototypes" compiler option, which isn't valid for C++.


### PR DESCRIPTION
Seems to be necessary for the dist target in the Makefile;
was missed in the earlier commit.